### PR TITLE
fix(marking): removing the marking slider as conflicts with key shortcuts

### DIFF
--- a/src/main/webapp/app/scanexam/corrigequestion/corrigequestion.component.html
+++ b/src/main/webapp/app/scanexam/corrigequestion/corrigequestion.component.html
@@ -98,17 +98,7 @@
               [(ngModel)]="currentNote"
               (onRate)="changeNote()"
             ></p-rating>
-            <p-slider
-              [disabled]="currentQuestion !== undefined && currentQuestion?.gradeType !== 'DIRECT'"
-              *ngIf="noteSteps > 0"
-              [ngModel]="currentNote"
-              [min]="0"
-              [max]="maxNote * questionStep"
-              [step]="1"
-              (onChange)="changeNoteSlider($event)"
-            >
-            </p-slider>
-            Note attribuée: {{ currentNote / questionStep }}
+            Note attribuée : {{ currentNote / questionStep }}
           </div>
           <div *ngIf="resp" style="padding-bottom: 1rem" class="col-3 sm:col-3 md:col-3 lg:col-3 xl:col-12">
             <label>Excellente réponse: </label>

--- a/src/main/webapp/app/scanexam/corrigequestion/corrigequestion.component.ts
+++ b/src/main/webapp/app/scanexam/corrigequestion/corrigequestion.component.ts
@@ -317,13 +317,6 @@ export class CorrigequestionComponent implements OnInit, AfterViewInit {
     }
   }
 
-  changeNoteSlider(event: any): void {
-    if (event.value !== this.currentNote) {
-      this.currentNote = event.value;
-      this.changeNote();
-    }
-  }
-
   updateResponse(): void {
     if (this.resp !== undefined) {
       this.studentResponseService.update(this.resp!).subscribe(sr1 => (this.resp = sr1.body!));


### PR DESCRIPTION
When using the marking slider, it grabs the key focus.
If you then switch to the next student using key shortcuts, **it also changes the slider' value** as this last has the focus and arrow right/left keys change slider's value.
No simple way for disabling key events for slider so disabling it as it is not very useful (IMO).