### PR TITLE
Adjustment of the statistics page for windows with a small width

### DIFF
--- a/src/main/webapp/app/scanexam/scanexam.module.ts
+++ b/src/main/webapp/app/scanexam/scanexam.module.ts
@@ -61,6 +61,8 @@ import { StatsExamComponent } from './statsexam/statsexam.component';
 import { CardModule } from 'primeng/card';
 import { ChartModule } from 'primeng/chart';
 import { KnobModule } from 'primeng/knob';
+import { DropdownModule } from 'primeng/dropdown';
+import { ToggleButtonModule } from 'primeng/togglebutton';
 
 // set the location of the OpenCV files
 registerAllModules();
@@ -255,6 +257,8 @@ export const ShowResults_ROUTE: Route = {
     ButtonModule,
     ChartModule,
     KnobModule,
+    DropdownModule,
+    ToggleButtonModule,
     SharedModule,
     FontAwesomeModule,
     BlockUIModule,

--- a/src/main/webapp/app/scanexam/statsexam/statsexam.component.html
+++ b/src/main/webapp/app/scanexam/statsexam/statsexam.component.html
@@ -80,6 +80,7 @@
     <p-card id="selection_etudiant" header="Sélection d'un étudiant" subheader="Aucun étudiant sélectionné">
       <ng-template pTemplate="header">
         <p-table
+          class="computer-view"
           [value]="this.infosStudents"
           selectionMode="single"
           [(selection)]="this.etudiantSelec"
@@ -109,6 +110,43 @@
             </tr>
           </ng-template>
         </p-table>
+        <div class="mobile-view">
+          <div class="selectstudentmobile">
+            <p-dropdown
+              [options]="this.listeMobileEtudiant"
+              [(ngModel)]="etudiantSelec"
+              optionValue="value"
+              optionLabel="name"
+              [showClear]="true"
+              placeholder="Aucun étudiant sélectionné"
+              dropdownIcon="pi pi-user"
+              tooltipPosition="bottom"
+              (onChange)="onStudentSelect($event)"
+              (onClear)="onStudentUnselect($event)"
+              scrollHeight="150px"
+              showTransitionOptions=".4s ease-in-out"
+              hideTransitionOptions=".5s ease-in-out"
+            ></p-dropdown>
+            <div class="changementTriMobile">
+              <p-selectButton
+                (onChange)="changementTriMobile()"
+                [options]="mobileSortChoices"
+                [(ngModel)]="mobileSortChoice"
+                optionLabel="icon"
+              >
+                <ng-template let-item>
+                  <i [class]="item.icon"></i>
+                </ng-template>
+              </p-selectButton>
+              <p-toggleButton
+                (onChange)="changementTriMobile()"
+                [(ngModel)]="choixTri"
+                onIcon="{{ this.ICONSORTUP }}"
+                offIcon="pi pi-sort-amount-down-alt"
+              ></p-toggleButton>
+            </div>
+          </div>
+        </div>
       </ng-template>
       <div class="card-body">
         <div *ngIf="etudiantSelec !== null && etudiantSelec !== undefined">

--- a/src/main/webapp/app/scanexam/statsexam/statsexam.component.scss
+++ b/src/main/webapp/app/scanexam/statsexam/statsexam.component.scss
@@ -37,39 +37,73 @@
     // Taille par défaut de la carte
     width: 300px;
   }
+  .mobile-view {
+    display: none;
+  }
 }
 @media (max-width: 1100px) {
   .cards {
     flex-direction: column;
   }
   .card {
-    width: 100%;
+    width: 100% !important;
   }
   #statgen {
-    order: 3;
+    order: 1;
   }
   .statgenerale {
     word-wrap: break-word;
     text-align: center;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    width: 20rem;
   }
   #statsquestions {
-    order: 2;
-    max-width: 90%;
+    order: 3;
   }
   #selectstudent {
-    order: 1;
+    order: 2;
   }
   .statsgenerales-container {
     display: flex;
     width: 100%;
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: center;
+    // flex-direction: column;
   }
   .radar-container {
     width: min-content;
+  }
+  .computer-view {
+    display: none;
+  }
+  .selectstudentmobile {
+    display: flex;
+    padding: 15px;
+    justify-content: space-around;
+    align-items: center;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    gap: 15px;
+  }
+  .changementTriMobile {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 50px;
+  }
+  :host ::ng-deep .p-dropdown {
+    width: 20rem;
+  }
+  :host ::ng-deep .p-dropdown-items {
+    width: 19rem;
+  }
+  :host ::ng-deep .p-dropdown-item {
+    overflow: auto;
+    word-break: break-all;
+    word-wrap: break-word;
+  }
+  :host ::ng-deep .p-togglebutton {
+    border-radius: 20px;
   }
 }
 


### PR DESCRIPTION
The board becomes a dropdown list when the screen is small. It is easier for the user to select and see all the student data. The sorting feature is kept, available with buttons. 
![image](https://user-images.githubusercontent.com/62034725/179463744-a65df956-918f-4388-8a49-45da19dd7b59.png)
