### PR TITLE
fix(pkg): update node canvas to work with node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/node": "18.11.7",
         "bootstrap": "5.2.2",
         "browser-sync-client": "^2.27.10",
-        "canvas": "^2.10.1",
+        "canvas": "^2.10.2",
         "chart.js": "^3.8.0",
         "dayjs": "1.11.6",
         "dexie": "^3.2.2",
@@ -7911,13 +7911,13 @@
       ]
     },
     "node_modules/canvas": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.1.tgz",
-      "integrity": "sha512-29pIjn9uwTUsIgJUNd7GXxKk8sg4iyJwLm1wIilNIqX1mVzXSc2nUij9exW1LqNpis1d2ebMYfMqTWcokZ4pdA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.0.tgz",
+      "integrity": "sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "simple-get": "^3.0.3"
       },
       "engines": {
@@ -31779,12 +31779,12 @@
       "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A=="
     },
     "canvas": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.1.tgz",
-      "integrity": "sha512-29pIjn9uwTUsIgJUNd7GXxKk8sg4iyJwLm1wIilNIqX1mVzXSc2nUij9exW1LqNpis1d2ebMYfMqTWcokZ4pdA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.0.tgz",
+      "integrity": "sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "simple-get": "^3.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/node": "18.11.7",
     "bootstrap": "5.2.2",
     "browser-sync-client": "^2.27.10",
-    "canvas": "^2.10.1",
+    "canvas": "^2.10.2",
     "chart.js": "^3.8.0",
     "dayjs": "1.11.6",
     "dexie": "^3.2.2",


### PR DESCRIPTION
Currently, `npm install` fails while installing node-canvas with node 18.
The version 2.10.2 of node-canvas fixes the support of node 18