### PR TITLE
fix(template): incorrect exam points sum

### DIFF
--- a/src/main/webapp/app/scanexam/annotate-template/summary/summary-template.component.ts
+++ b/src/main/webapp/app/scanexam/annotate-template/summary/summary-template.component.ts
@@ -19,6 +19,7 @@ export class SummaryTemplateComponent {
    */
   public sumPoints(): number {
     return this.getSortedQuestions()
+      .filter((q, i) => !this.isFollowingQuestion(i, q))
       .map(q => q.point ?? 0)
       .reduce((a, b) => a + b, 0);
   }


### PR DESCRIPTION
The last update of the template component has a bug when summing the points of an exam where a question is divided in several zones.