### PR TITLE
feat(usab): can change the name of exams and courses

### DIFF
--- a/src/main/webapp/app/scanexam/coursdetail/coursdetails.component.html
+++ b/src/main/webapp/app/scanexam/coursdetail/coursdetails.component.html
@@ -14,7 +14,13 @@
     <div class="wizard-image"></div>
     <div class="wizard-form">
       <div class="wizard-header">
-        <h3>{{ course?.name }}</h3>
+        <jhi-usable-text-input
+          [name]="this.course?.name ?? ''"
+          [tooltip]="'scanexam.tooltipeditcoursename' | translate"
+          [placeholder]="'scanexam.placeholdereditcoursename' | translate"
+          (newValue)="onCourseNameChanged($event)"
+        >
+        </jhi-usable-text-input>
         <p jhiTranslate="scanexam.slogan">Vos exams accessibles en un clic</p>
       </div>
       <div id="form-total" #formTotal>

--- a/src/main/webapp/app/scanexam/coursdetail/coursdetails.component.scss
+++ b/src/main/webapp/app/scanexam/coursdetail/coursdetails.component.scss
@@ -167,12 +167,6 @@ input:checked + .slider1:before {
   width: 100%;
   padding: 40px 73px 40px 52px;
 }
-.wizard-form .wizard-header h3 {
-  color: #333;
-  font-size: 36px;
-  font-weight: 800;
-  margin: 0;
-}
 .wizard-form .wizard-header p {
   color: #666;
   font-size: 16px;

--- a/src/main/webapp/app/scanexam/coursdetail/coursdetails.component.ts
+++ b/src/main/webapp/app/scanexam/coursdetail/coursdetails.component.ts
@@ -20,6 +20,7 @@ import { ApplicationConfigService } from '../../core/config/application-config.s
 import { DialogService } from 'primeng/dynamicdialog';
 import { SharecourseComponent } from '../sharecourse/sharecourse.component';
 import { TranslateService } from '@ngx-translate/core';
+import { firstValueFrom } from 'rxjs';
 @Component({
   selector: 'jhi-coursdetails',
   templateUrl: './coursdetails.component.html',
@@ -147,5 +148,15 @@ export class CoursdetailsComponent implements OnInit {
 
   gobacktomodulelist(): void {
     this.router.navigateByUrl('/');
+  }
+
+  onCourseNameChanged(newName: string): void {
+    const oldName = this.course!.name;
+
+    this.course!.name = newName;
+
+    firstValueFrom(this.courseService.update(this.course!)).catch(() => {
+      this.course!.name = oldName;
+    });
   }
 }

--- a/src/main/webapp/app/scanexam/exam-detail/exam-detail.component.html
+++ b/src/main/webapp/app/scanexam/exam-detail/exam-detail.component.html
@@ -31,10 +31,13 @@
 
     <div class="wizard-image"></div>
     <div class="wizard-form">
-      <div class="wizard-header">
-        <h3>{{ exam?.name }}</h3>
-        <p jhiTranslate="scanexam.slogan">Vos exams accessibles en un clic</p>
-      </div>
+      <jhi-usable-text-input
+        [name]="this.exam?.name ?? ''"
+        [tooltip]="'scanexam.tooltipeditexamname' | translate"
+        [placeholder]="'scanexam.placeholdereditexamname' | translate"
+        (newValue)="onExamNameChanged($event)"
+      >
+      </jhi-usable-text-input>
       <div id="form-total" #formTotal>
         <div class="inner" [style]="{ 'text-align': 'center' }">
           <button

--- a/src/main/webapp/app/scanexam/exam-detail/exam-detail.component.scss
+++ b/src/main/webapp/app/scanexam/exam-detail/exam-detail.component.scss
@@ -167,18 +167,7 @@ input:checked + .slider1:before {
   width: 100%;
   padding: 40px 73px 40px 52px;
 }
-.wizard-form .wizard-header h3 {
-  color: #333;
-  font-size: 36px;
-  font-weight: 800;
-  margin: 0;
-}
-.wizard-form .wizard-header p {
-  color: #666;
-  font-size: 16px;
-  font-weight: 600;
-  margin: 6px 0 26px;
-}
+
 .form-register .steps {
   margin-bottom: 36px;
 }

--- a/src/main/webapp/app/shared/shared-libs.module.ts
+++ b/src/main/webapp/app/shared/shared-libs.module.ts
@@ -5,8 +5,24 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
+import { ToggleButtonModule } from 'primeng/togglebutton';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { TooltipModule } from 'primeng/tooltip';
 
 @NgModule({
-  exports: [FormsModule, CommonModule, NgbModule, InfiniteScrollModule, FontAwesomeModule, ReactiveFormsModule, TranslateModule],
+  exports: [
+    FormsModule,
+    CommonModule,
+    NgbModule,
+    InfiniteScrollModule,
+    FontAwesomeModule,
+    ReactiveFormsModule,
+    TranslateModule,
+    ToggleButtonModule,
+    ButtonModule,
+    InputTextModule,
+    TooltipModule,
+  ],
 })
 export class SharedLibsModule {}

--- a/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/webapp/app/shared/shared.module.ts
@@ -12,6 +12,7 @@ import { FormatMediumDatePipe } from './date/format-medium-date.pipe';
 import { SortByDirective } from './sort/sort-by.directive';
 import { SortDirective } from './sort/sort.directive';
 import { ItemCountComponent } from './pagination/item-count.component';
+import { UsableTextInputComponent } from './usable-text-input/usable-text-input.component';
 
 @NgModule({
   imports: [SharedLibsModule],
@@ -27,6 +28,7 @@ import { ItemCountComponent } from './pagination/item-count.component';
     SortByDirective,
     SortDirective,
     ItemCountComponent,
+    UsableTextInputComponent,
   ],
   exports: [
     SharedLibsModule,
@@ -41,6 +43,7 @@ import { ItemCountComponent } from './pagination/item-count.component';
     SortByDirective,
     SortDirective,
     ItemCountComponent,
+    UsableTextInputComponent,
   ],
 })
 export class SharedModule {}

--- a/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.html
+++ b/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.html
@@ -1,0 +1,30 @@
+<div class="usable-input-text">
+  <p-button
+    class="no-label"
+    icon="pi pi-times"
+    [ngStyle]="{ visibility: textIsEditing ? '' : 'hidden' }"
+    (onClick)="cancelEdit(nameInput)"
+  ></p-button>
+  <p-toggleButton
+    #editButton
+    [pTooltip]="tooltip"
+    offIcon="pi pi-pencil"
+    onIcon="pi pi-check"
+    [attr.aria-label]="tooltip"
+    (onChange)="onToggleButton(nameInput)"
+    [disabled]="nameInput.value.length === 0"
+    [ngModel]="textIsEditing"
+  >
+  </p-toggleButton>
+  <input
+    #nameInput
+    pInputText
+    class="nameedit"
+    id="examname"
+    [placeholder]="placeholder"
+    [readonly]="!textIsEditing"
+    [ngModel]="name"
+    required
+  />
+  <!-- TODO error message on REST query error -->
+</div>

--- a/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.scss
+++ b/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.scss
@@ -1,0 +1,24 @@
+::ng-deep .no-label .p-button-label {
+  display: none !important;
+}
+
+.nameedit {
+  font-size: x-large !important;
+  font-weight: bold !important;
+  color: black !important;
+}
+
+.nameedit[readonly] {
+  border-style: hidden !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+}
+.usable-input-text {
+  padding: 10px 0 0 0;
+  display: flex;
+  align-items: center;
+}
+
+.usable-input-text * {
+  padding: 3px !important;
+}

--- a/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.spec.ts
+++ b/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UsableTextInputComponent } from './usable-text-input.component';
+
+describe('UsableTextInputComponent', () => {
+  let component: UsableTextInputComponent;
+  let fixture: ComponentFixture<UsableTextInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [UsableTextInputComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UsableTextInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.ts
+++ b/src/main/webapp/app/shared/usable-text-input/usable-text-input.component.ts
@@ -1,0 +1,37 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'jhi-usable-text-input',
+  templateUrl: './usable-text-input.component.html',
+  styleUrls: ['./usable-text-input.component.scss'],
+})
+export class UsableTextInputComponent {
+  public textIsEditing = false;
+
+  @Input()
+  public name = '';
+
+  @Input()
+  public tooltip = '';
+
+  @Input()
+  public placeholder = '';
+
+  @Output()
+  private newValue = new EventEmitter<string>();
+
+  public onToggleButton(textInput: HTMLInputElement): void {
+    if (this.textIsEditing && this.name !== textInput.value) {
+      this.newValue.next(textInput.value);
+    }
+
+    this.textIsEditing = !this.textIsEditing;
+  }
+
+  public cancelEdit(textInput: HTMLInputElement): void {
+    this.textIsEditing = false;
+    textInput.value = this.name;
+    // Dirty, but required to launch the validation
+    textInput.dispatchEvent(new Event('input'));
+  }
+}

--- a/src/main/webapp/i18n/en/scanexammodule.json
+++ b/src/main/webapp/i18n/en/scanexammodule.json
@@ -1,5 +1,9 @@
 {
   "scanexam": {
+    "tooltipeditcoursename": "Change the course name",
+    "tooltipeditexamname": "Change the exam name",
+    "placeholdereditcoursename": "Set here the course name",
+    "placeholdereditexamname": "Set here the exam name",
     "error": "Cannot retreive the information",
     "questions": "Questions",
     "questionLow": "Question",

--- a/src/main/webapp/i18n/fr/scanexammodule.json
+++ b/src/main/webapp/i18n/fr/scanexammodule.json
@@ -1,5 +1,9 @@
 {
   "scanexam": {
+    "tooltipeditcoursename": "Changer le nom du cours",
+    "tooltipeditexamname": "Changer le nom de l'examen",
+    "placeholdereditcoursename": "Définir ici le nom du cours",
+    "placeholdereditexamname": "Définir ici le nom de l'examen",
     "error": "Impossible de récupérer les informations",
     "questions": "Questions",
     "questionLow": "Question",


### PR DESCRIPTION
Fixes issues reported in the AIR usab report.
Required the creation of a new widget since the primeng (\inplace`) one is not good enough.